### PR TITLE
Fix/prop py

### DIFF
--- a/redeem-classifiers/Cargo.toml
+++ b/redeem-classifiers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redeem-classifiers"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Justin Sing <justincsing@gmail.com>"]
 edition = "2021"
 rust-version = "1.76"

--- a/redeem-properties-py/Cargo.toml
+++ b/redeem-properties-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redeem-properties-py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Python bindings for redeem-properties peptide property prediction models"
 

--- a/redeem-properties-py/python/redeem_properties/__init__.py
+++ b/redeem-properties-py/python/redeem_properties/__init__.py
@@ -33,6 +33,7 @@ Quick start
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Optional
 
 from redeem_properties._lib import (  # noqa: F401  (re-exported)
@@ -50,6 +51,7 @@ from redeem_properties._lib import (  # noqa: F401  (re-exported)
 )
 
 __all__ = [
+    "__version__",
     "RTModel",
     "CCSModel",
     "MS2Model",
@@ -62,6 +64,19 @@ __all__ = [
     "match_fragment_mzs",
     "ccs_to_mobility",
 ]
+
+
+def _detect_version() -> str:
+    """Return the installed package version for redeem_properties."""
+    for dist_name in ("redeem_properties", "redeem-properties-py"):
+        try:
+            return version(dist_name)
+        except PackageNotFoundError:
+            continue
+    return "0+unknown"
+
+
+__version__ = _detect_version()
 
 
 # ---------------------------------------------------------------------------

--- a/redeem-properties-py/src/lib.rs
+++ b/redeem-properties-py/src/lib.rs
@@ -81,8 +81,8 @@ fn resolve_pretrained(name: &str, family: &str) -> PyResult<(String, PathBuf)> {
 /// This function searches the pretrained model registry for the given model name.
 /// It checks the following locations in order:
 ///   1. The directory specified by the `REDEEM_PRETRAINED_MODELS_DIR` environment variable.
-///   2. The `data/pretrained_models/` directory relative to the current working directory.
-///   3. The user's local data directory (e.g., `~/.local/share/redeem/models/` on Linux).
+///   2. The user's local data directory (e.g., `~/.local/share/redeem/pretrained_models/` on Linux).
+///   3. The `data/pretrained_models/` directory in development locations.
 ///
 /// Args:
 ///     name (str): The identifier of the pretrained model (e.g., "rt", "ccs", "ms2").
@@ -172,9 +172,10 @@ fn validate_pretrained(py: Python, name: &str) -> PyResult<PyObject> {
 /// ``RTModel.from_pretrained()``, ``CCSModel.from_pretrained()``, and
 /// ``MS2Model.from_pretrained()``.
 ///
-/// The models are downloaded to ``data/pretrained_models/`` relative to the current
-/// working directory. If the models already exist, this function returns immediately
-/// without re-downloading.
+/// The models are downloaded to a stable user-local directory (or
+/// ``REDEEM_PRETRAINED_MODELS_DIR`` when set), so they are reusable across working
+/// directories. If the models already exist, this function returns immediately without
+/// re-downloading.
 ///
 /// Returns:
 ///     str: The absolute path to the extracted pretrained models directory.
@@ -240,8 +241,8 @@ impl RTModel {
     /// Models are located using the ``redeem_properties`` pretrained-model registry.
     /// On first use the search order is:
     ///   1. ``$REDEEM_PRETRAINED_MODELS_DIR/<name>``
-    ///   2. ``data/pretrained_models/`` relative to the current directory
-    ///   3. ``$HOME/.local/share/redeem/models/<name>``
+    ///   2. user-local pretrained directory (e.g. ``~/.local/share/redeem/pretrained_models``)
+    ///   3. ``data/pretrained_models/`` development locations
     ///
     /// Accepted ``name`` values (case-insensitive):
     ///   - ``"rt"`` / ``"alphapeptdeep-rt"`` / ``"alphapeptdeep-rt-cnn-lstm"``

--- a/redeem-properties/Cargo.toml
+++ b/redeem-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redeem-properties"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Justin Sing <justincsing@gmail.com>"]
 edition = "2021"
 rust-version = "1.76"

--- a/redeem-properties/src/building_blocks/building_blocks.rs
+++ b/redeem-properties/src/building_blocks/building_blocks.rs
@@ -1687,30 +1687,36 @@ impl Encoder26aaModChargeCnnTransformerAttnSum {
 
 #[cfg(test)]
 mod tests {
+    use crate::pretrained::{locate_pretrained_model, PretrainedModel};
     use candle_core::Device;
     use candle_nn::VarBuilder;
     use std::path::PathBuf;
 
     use super::*;
 
-    /// Ensure pretrained models are downloaded before tests that need them.
     fn ensure_models() {
         crate::utils::peptdeep_utils::download_pretrained_models_exist()
             .expect("Failed to download pretrained models");
     }
 
+    fn resolved_model_and_constants(pm: PretrainedModel) -> (PathBuf, PathBuf) {
+        let model_path = locate_pretrained_model(pm).expect("Failed to locate pretrained model");
+        let ext = model_path
+            .extension()
+            .and_then(|s| s.to_str())
+            .expect("Pretrained model path has no extension");
+        let constants_path = model_path.with_extension(format!("{}.model_const.yaml", ext));
+        (model_path, constants_path)
+    }
+
     #[test]
     fn test_decoder_linear_new() -> Result<()> {
-        // Set up the device and random seed
         let device = Device::Cpu;
-
-        // Create an instance of DecoderLinear
         let in_features = 10;
         let out_features = 5;
         let vb = VarBuilder::zeros(DType::F32, &device);
         let decoder_linear = DecoderLinear::new(in_features, out_features, &vb.pp("output_nn"))?;
 
-        // Create the input tensor
         let x = Tensor::new(
             &[
                 [
@@ -1730,22 +1736,11 @@ mod tests {
         )?
         .to_dtype(DType::F32)?;
 
-        // Perform forward pass
         let output = decoder_linear.forward(&x)?;
-
-        println!("Output:\n{}", output);
-
-        // With VarBuilder::zeros, all weights and biases are zero, so the output should be all zeros
         let expected_output = Tensor::zeros((3, out_features), DType::F32, &device)?;
 
-        // Check output shape
-        assert_eq!(
-            output.shape(),
-            expected_output.shape(),
-            "Output shape mismatch"
-        );
+        assert_eq!(output.shape(), expected_output.shape(), "Output shape mismatch");
 
-        // Check output values are all zero (since weights are zero)
         let output_vec = output.to_vec2::<f32>()?;
         for row in &output_vec {
             for &val in row {
@@ -1757,26 +1752,17 @@ mod tests {
             }
         }
 
-        // Print shapes for verification
-        println!("Input shape: {:?}", x.shape());
-        println!("Output shape: {:?}", output.shape());
-        println!("Output:\n{}", output);
-
         Ok(())
     }
 
     #[test]
     fn test_decoder_linear() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1800,15 +1786,11 @@ mod tests {
     #[test]
     fn test_mod_embedding_fix_first_k() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1827,15 +1809,11 @@ mod tests {
     #[test]
     fn test_aa_embedding() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1848,15 +1826,11 @@ mod tests {
     #[test]
     fn test_positional_encoding() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1871,15 +1845,11 @@ mod tests {
     #[test]
     fn test_input_26aa_mod_positional_encoding() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1902,16 +1872,11 @@ mod tests {
     #[test]
     fn test_meta_embedding() {
         ensure_models();
-
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1929,15 +1894,11 @@ mod tests {
     #[test]
     fn test_hidden_hface_transformer() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1959,15 +1920,11 @@ mod tests {
     #[test]
     fn test_mod_loss_nn() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepMs2Bert);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -1997,15 +1954,11 @@ mod tests {
     #[test]
     fn test_seq_cnn() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepCcsCnnLstm);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -2032,15 +1985,11 @@ mod tests {
     #[test]
     fn test_seq_lstm() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepCcsCnnLstm);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();
@@ -2054,15 +2003,11 @@ mod tests {
     #[test]
     fn test_seq_attention_sum() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) =
+            resolved_model_and_constants(PretrainedModel::AlphapeptdeepCcsCnnLstm);
 
         assert!(model_path.exists(), "Test model file does not exist");
-        assert!(
-            constants_path.exists(),
-            "Test constants file does not exist"
-        );
+        assert!(constants_path.exists(), "Test constants file does not exist");
 
         let var_store =
             VarBuilder::from_pth(model_path, candle_core::DType::F32, &Device::Cpu).unwrap();

--- a/redeem-properties/src/building_blocks/featurize.rs
+++ b/redeem-properties/src/building_blocks/featurize.rs
@@ -229,6 +229,7 @@ pub fn get_mod_features_from_parsed_arc(
 #[cfg(test)]
 mod tests {
 
+    use crate::pretrained::{locate_pretrained_model, PretrainedModel};
     use crate::utils::peptdeep_utils::parse_model_constants;
     use crate::utils::peptdeep_utils::ModelConstants;
     use crate::utils::peptdeep_utils::{load_mod_to_feature, load_mod_to_feature_arc};
@@ -303,8 +304,9 @@ mod tests {
         let seq_len = 11 + 2;
         let mod_feature_size = 109;
 
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth.model_const.yaml");
+        let model_path = locate_pretrained_model(PretrainedModel::AlphapeptdeepRtCnnLstm)
+            .expect("Failed to locate RT pretrained model");
+        let constants_path = model_path.with_extension("pth.model_const.yaml");
         let constants: ModelConstants =
             parse_model_constants(constants_path.to_str().unwrap()).unwrap();
         let mod_to_feature: HashMap<String, Vec<f32>> = load_mod_to_feature(&constants).unwrap();

--- a/redeem-properties/src/models/ccs_cnn_lstm_model.rs
+++ b/redeem-properties/src/models/ccs_cnn_lstm_model.rs
@@ -298,6 +298,7 @@ mod tests {
     use super::*;
     use crate::models::ccs_cnn_lstm_model::CCSCNNLSTMModel;
     use crate::models::model_interface::ModelInterface;
+    use crate::pretrained::{locate_pretrained_model, PretrainedModel};
     use candle_core::Device;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -308,12 +309,17 @@ mod tests {
             .expect("Failed to download pretrained models");
     }
 
+    fn resolved_model_and_constants() -> (PathBuf, PathBuf) {
+        let model_path = locate_pretrained_model(PretrainedModel::AlphapeptdeepCcsCnnLstm)
+            .expect("Failed to locate CCS pretrained model");
+        let constants_path = model_path.with_extension("pth.model_const.yaml");
+        (model_path, constants_path)
+    }
+
     #[test]
     fn test_load_pretrained_ccs_cnn_lstm_model() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             CCSCNNLSTMModel::new(model_path, Some(constants_path), 0, 8, 4, true, device).unwrap();
@@ -324,9 +330,7 @@ mod tests {
     #[test]
     fn test_encode_peptides() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             CCSCNNLSTMModel::new(model_path, Some(constants_path), 0, 8, 4, true, device).unwrap();
@@ -362,9 +366,7 @@ mod tests {
     #[test]
     fn test_predict() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ccs.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
 
         let model =

--- a/redeem-properties/src/models/ms2_bert_model.rs
+++ b/redeem-properties/src/models/ms2_bert_model.rs
@@ -442,6 +442,7 @@ mod tests {
     use super::*;
     use crate::models::model_interface::ModelInterface;
     use crate::models::ms2_bert_model::MS2BertModel;
+    use crate::pretrained::{locate_pretrained_model, PretrainedModel};
     use candle_core::Device;
     use std::path::PathBuf;
 
@@ -451,11 +452,18 @@ mod tests {
             .expect("Failed to download pretrained models");
     }
 
+    fn resolved_model_and_constants() -> (PathBuf, PathBuf) {
+        let model_path = locate_pretrained_model(PretrainedModel::AlphapeptdeepMs2Bert)
+            .expect("Failed to locate MS2 pretrained model");
+        let constants_path = model_path.with_extension("pth.model_const.yaml");
+        (model_path, constants_path)
+    }
+
     #[test]
     fn test_parse_model_constants() {
         ensure_models();
-        let path = "data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml";
-        let result = parse_model_constants(path);
+        let (_, constants_path) = resolved_model_and_constants();
+        let result = parse_model_constants(constants_path.to_str().unwrap());
         assert!(result.is_ok());
         let constants = result.unwrap();
         assert_eq!(constants.aa_embedding_size.unwrap(), 27);
@@ -469,9 +477,7 @@ mod tests {
     #[test]
     fn test_load_pretrained_ms2_bert_model() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             MS2BertModel::new(model_path, Some(constants_path), 0, 8, 4, true, device).unwrap();
@@ -482,9 +488,7 @@ mod tests {
     #[test]
     fn test_encode_peptides() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             MS2BertModel::new(model_path, Some(constants_path), 0, 8, 4, true, device).unwrap();
@@ -510,9 +514,7 @@ mod tests {
     #[test]
     fn test_forward() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/ms2.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             MS2BertModel::new(model_path, Some(constants_path), 0, 8, 4, true, device).unwrap();

--- a/redeem-properties/src/models/rt_cnn_lstm_model.rs
+++ b/redeem-properties/src/models/rt_cnn_lstm_model.rs
@@ -333,6 +333,7 @@ impl ModelInterface for RTCNNLSTMModel {
 mod tests {
     use crate::models::model_interface::{ModelInterface, PredictionResult};
     use crate::models::rt_cnn_lstm_model::RTCNNLSTMModel;
+    use crate::pretrained::{locate_pretrained_model, PretrainedModel};
     use candle_core::Device;
     use std::path::PathBuf;
 
@@ -344,10 +345,17 @@ mod tests {
             .expect("Failed to download pretrained models");
     }
 
+    fn resolved_model_and_constants() -> (PathBuf, PathBuf) {
+        let model_path = locate_pretrained_model(PretrainedModel::AlphapeptdeepRtCnnLstm)
+            .expect("Failed to locate RT pretrained model");
+        let constants_path = model_path.with_extension("pth.model_const.yaml");
+        (model_path, constants_path)
+    }
+
     #[test]
     fn test_tensor_from_pth() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth");
+        let (model_path, _) = resolved_model_and_constants();
         let tensor_data = candle_core::pickle::read_all(model_path).unwrap();
         println!("{:?}", tensor_data);
     }
@@ -355,8 +363,8 @@ mod tests {
     #[test]
     fn test_parse_model_constants() {
         ensure_models();
-        let path = "data/pretrained_models/alphapeptdeep/generic/rt.pth.model_const.yaml";
-        let result = parse_model_constants(path);
+        let (_, constants_path) = resolved_model_and_constants();
+        let result = parse_model_constants(constants_path.to_str().unwrap());
         assert!(result.is_ok());
         let constants = result.unwrap();
         assert_eq!(constants.aa_embedding_size.unwrap(), 27);
@@ -370,9 +378,7 @@ mod tests {
     #[test]
     fn test_encode_peptides() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
         let model =
             RTCNNLSTMModel::new(&model_path, Some(&constants_path), 0, 8, 4, true, device).unwrap();
@@ -398,9 +404,7 @@ mod tests {
     #[test]
     fn test_encode_peptides_batch() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::Cpu;
 
         let model = RTCNNLSTMModel::new(
@@ -446,9 +450,7 @@ mod tests {
     #[test]
     fn test_prediction() {
         ensure_models();
-        let model_path = PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth");
-        let constants_path =
-            PathBuf::from("data/pretrained_models/alphapeptdeep/generic/rt.pth.model_const.yaml");
+        let (model_path, constants_path) = resolved_model_and_constants();
         let device = Device::new_cuda(0).unwrap_or(Device::Cpu);
         let mut model =
             RTCNNLSTMModel::new(&model_path, Some(&constants_path), 0, 8, 4, true, device).unwrap();

--- a/redeem-properties/src/pretrained/mod.rs
+++ b/redeem-properties/src/pretrained/mod.rs
@@ -48,6 +48,51 @@ impl PretrainedModel {
     }
 }
 
+/// Resolve a writable, cross-platform default directory for pretrained models.
+///
+/// Priority:
+/// 1. `$XDG_DATA_HOME/redeem/pretrained_models` (Linux/Unix)
+/// 2. `%LOCALAPPDATA%/redeem/pretrained_models` then `%APPDATA%/redeem/pretrained_models` (Windows)
+/// 3. `$HOME/Library/Application Support/redeem/pretrained_models` (macOS)
+/// 4. `$HOME/.local/share/redeem/pretrained_models` (Linux fallback)
+/// 5. `./.redeem_models_cache` (last resort)
+pub fn default_pretrained_models_dir() -> PathBuf {
+    if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return PathBuf::from(xdg).join("redeem/pretrained_models");
+        }
+    }
+
+    if let Ok(local_app_data) = env::var("LOCALAPPDATA") {
+        if !local_app_data.is_empty() {
+            return PathBuf::from(local_app_data).join("redeem/pretrained_models");
+        }
+    }
+
+    if let Ok(app_data) = env::var("APPDATA") {
+        if !app_data.is_empty() {
+            return PathBuf::from(app_data).join("redeem/pretrained_models");
+        }
+    }
+
+    if let Ok(home) = env::var("HOME") {
+        if !home.is_empty() {
+            #[cfg(target_os = "macos")]
+            {
+                return PathBuf::from(home)
+                    .join("Library/Application Support/redeem/pretrained_models");
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            {
+                return PathBuf::from(home).join(".local/share/redeem/pretrained_models");
+            }
+        }
+    }
+
+    PathBuf::from("./.redeem_models_cache")
+}
+
 impl std::str::FromStr for PretrainedModel {
     type Err = anyhow::Error;
 
@@ -170,9 +215,9 @@ impl PretrainedModel {
 ///
 /// Search order:
 /// 1. Directory pointed to by `REDEEM_PRETRAINED_MODELS_DIR` environment variable.
-/// 2. `data/pretrained_models/` relative to the crate (useful during development).
-/// 3. `data/pretrained_models/` in the current working directory.
-/// 4. User cache directory: `$HOME/.local/share/redeem/models/`.
+/// 2. User-local models directory (cross-platform; see `default_pretrained_models_dir`).
+/// 3. `data/pretrained_models/` relative to the crate (useful during development).
+/// 4. `data/pretrained_models/` in the current working directory.
 pub fn locate_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
     // If crate was built with `embed-pretrained`, try extracting embedded asset to cache first.
     #[cfg(feature = "embed-pretrained")]
@@ -189,7 +234,13 @@ pub fn locate_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
         }
     }
 
-    // 2) Try relative to the crate manifest dir (useful during development/running from repo)
+    // 2) User-local default models dir (stable across working directories)
+    let user_candidate = default_pretrained_models_dir().join(model.filename());
+    if user_candidate.exists() {
+        return Ok(user_candidate);
+    }
+
+    // 3) Try relative to the crate manifest dir (useful during development/running from repo)
     if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
         let candidate = Path::new(&manifest)
             .join("data/pretrained_models")
@@ -199,25 +250,16 @@ pub fn locate_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
         }
     }
 
-    // 3) Try ./data/pretrained_models in current working dir
+    // 4) Try ./data/pretrained_models in current working dir
     let cwd_candidate = Path::new("data/pretrained_models").join(model.filename());
     if cwd_candidate.exists() {
         return Ok(cwd_candidate);
     }
 
-    // 4) User cache: $HOME/.local/share/redeem/models/<filename>
-    if let Ok(home) = env::var("HOME") {
-        let user_candidate = Path::new(&home)
-            .join(".local/share/redeem/models")
-            .join(model.filename());
-        if user_candidate.exists() {
-            return Ok(user_candidate);
-        }
-    }
-
     Err(anyhow::anyhow!(
-        "Pretrained model not found for {:?}. Try setting REDEEM_PRETRAINED_MODELS_DIR or placing the models under data/pretrained_models/",
-        model
+        "Pretrained model not found for {:?}. Looked in REDEEM_PRETRAINED_MODELS_DIR, {}, crate data/pretrained_models, and cwd data/pretrained_models.",
+        model,
+        default_pretrained_models_dir().display()
     ))
 }
 
@@ -226,14 +268,7 @@ pub fn locate_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
 #[cfg(feature = "embed-pretrained")]
 fn extract_embedded_model_to_cache(model: &PretrainedModel) -> Result<PathBuf> {
     if let Some(file) = EMBEDDED_PRETRAINED_DIR.get_file(model.filename()) {
-        // target cache dir: $XDG_DATA_HOME/redeem/models or fallback to $HOME/.local/share/redeem/models
-        let target_base = if let Ok(xdg) = env::var("XDG_DATA_HOME") {
-            PathBuf::from(xdg).join("redeem/models")
-        } else if let Ok(home) = env::var("HOME") {
-            PathBuf::from(home).join(".local/share/redeem/models")
-        } else {
-            PathBuf::from("./.redeem_models_cache")
-        };
+        let target_base = default_pretrained_models_dir();
 
         fs::create_dir_all(&target_base).with_context(|| {
             format!("Failed to create cache directory {}", target_base.display())
@@ -263,14 +298,7 @@ fn extract_embedded_model_to_cache(model: &PretrainedModel) -> Result<PathBuf> {
 /// This is helpful when downstream code expects a stable file path (for example loader functions).
 pub fn cache_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
     let src = locate_pretrained_model(model.clone())?;
-    // target cache dir: $XDG_DATA_HOME/redeem/models or fallback to $HOME/.local/share/redeem/models
-    let target_base = if let Ok(xdg) = env::var("XDG_DATA_HOME") {
-        PathBuf::from(xdg).join("redeem/models")
-    } else if let Ok(home) = env::var("HOME") {
-        PathBuf::from(home).join(".local/share/redeem/models")
-    } else {
-        PathBuf::from("./.redeem_models_cache")
-    };
+    let target_base = default_pretrained_models_dir();
 
     fs::create_dir_all(&target_base)
         .with_context(|| format!("Failed to create cache directory {}", target_base.display()))?;

--- a/redeem-properties/src/pretrained/mod.rs
+++ b/redeem-properties/src/pretrained/mod.rs
@@ -93,6 +93,18 @@ pub fn default_pretrained_models_dir() -> PathBuf {
     PathBuf::from("./.redeem_models_cache")
 }
 
+/// Resolve the configured pretrained-models directory for writes.
+///
+/// If `REDEEM_PRETRAINED_MODELS_DIR` is set and non-empty, it takes precedence.
+/// Otherwise, fall back to the cross-platform default user-local location.
+fn configured_pretrained_models_dir() -> PathBuf {
+    env::var("REDEEM_PRETRAINED_MODELS_DIR")
+        .ok()
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_pretrained_models_dir)
+}
+
 impl std::str::FromStr for PretrainedModel {
     type Err = anyhow::Error;
 
@@ -268,7 +280,7 @@ pub fn locate_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
 #[cfg(feature = "embed-pretrained")]
 fn extract_embedded_model_to_cache(model: &PretrainedModel) -> Result<PathBuf> {
     if let Some(file) = EMBEDDED_PRETRAINED_DIR.get_file(model.filename()) {
-        let target_base = default_pretrained_models_dir();
+        let target_base = configured_pretrained_models_dir();
 
         fs::create_dir_all(&target_base).with_context(|| {
             format!("Failed to create cache directory {}", target_base.display())
@@ -298,7 +310,7 @@ fn extract_embedded_model_to_cache(model: &PretrainedModel) -> Result<PathBuf> {
 /// This is helpful when downstream code expects a stable file path (for example loader functions).
 pub fn cache_pretrained_model(model: PretrainedModel) -> Result<PathBuf> {
     let src = locate_pretrained_model(model.clone())?;
-    let target_base = default_pretrained_models_dir();
+    let target_base = configured_pretrained_models_dir();
 
     fs::create_dir_all(&target_base)
         .with_context(|| format!("Failed to create cache directory {}", target_base.display()))?;

--- a/redeem-properties/src/utils/peptdeep_utils.rs
+++ b/redeem-properties/src/utils/peptdeep_utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Error, Result};
+use anyhow::{Error, Result};
 use csv::ReaderBuilder;
 use log::info;
 use once_cell::sync::Lazy;
@@ -20,8 +20,6 @@ const MODIFICATIONS_TSV_BYTES: &[u8] = include_bytes!(concat!(
 ));
 
 const PRETRAINED_MODELS_URL: &str = "https://github.com/singjc/redeem/releases/download/v0.1.0-alpha/pretrained_models.zip";
-const PRETRAINED_MODELS_ZIP: &str = "data/pretrained_models.zip";
-const PRETRAINED_MODELS_PATH: &str = "data/pretrained_models";
 
 // Constants and Utility Structs
 
@@ -546,8 +544,12 @@ pub fn download_pretrained_models_exist() -> Result<PathBuf, io::Error> {
 }
 
 fn download_pretrained_models_inner() -> Result<PathBuf, io::Error> {
-    let zip_path = PathBuf::from(PRETRAINED_MODELS_ZIP);
-    let extract_dir = PathBuf::from(PRETRAINED_MODELS_PATH);
+    let extract_dir = if let Ok(dir) = std::env::var("REDEEM_PRETRAINED_MODELS_DIR") {
+        PathBuf::from(dir)
+    } else {
+        crate::pretrained::default_pretrained_models_dir()
+    };
+    let zip_path = extract_dir.join("pretrained_models.zip");
 
     // If already fully extracted, return immediately
     if extract_dir.exists() {
@@ -607,19 +609,27 @@ fn download_pretrained_models_inner() -> Result<PathBuf, io::Error> {
         fs::rename(&tmp_path, &zip_path)?;
     }
 
-    // Unzip into the parent directory (e.g., "data/") so that the zip's
-    // top-level "pretrained_models/" folder lands at "data/pretrained_models/".
+    // Unzip directly into `extract_dir`. If the archive has a top-level
+    // "pretrained_models/" folder, strip that prefix first.
     info!("Unzipping pretrained models...");
     let file = File::open(&zip_path)?;
     let mut archive = ZipArchive::new(file)?;
 
-    let parent_dir = extract_dir
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
+    fs::create_dir_all(&extract_dir)?;
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
-        let outpath = parent_dir.join(file.mangled_name());
+        let archive_path = file.mangled_name();
+        let relative_path = archive_path
+            .strip_prefix("pretrained_models")
+            .unwrap_or(archive_path.as_path());
+
+        // Skip entries that correspond to the stripped root itself.
+        if relative_path.as_os_str().is_empty() {
+            continue;
+        }
+
+        let outpath = extract_dir.join(relative_path);
 
         if file.name().ends_with('/') {
             fs::create_dir_all(&outpath)?;
@@ -730,7 +740,12 @@ mod tests {
         assert!(path.is_dir(), "Pretrained models path is not a directory: {:?}", path);
         
         // Check that the path matches expected location
-        assert_eq!(path, PathBuf::from(PRETRAINED_MODELS_PATH));
+        let expected = if let Ok(dir) = std::env::var("REDEEM_PRETRAINED_MODELS_DIR") {
+            PathBuf::from(dir)
+        } else {
+            crate::pretrained::default_pretrained_models_dir()
+        };
+        assert_eq!(path, expected);
         
         println!("Pretrained models successfully available at: {:?}", path);
     }


### PR DESCRIPTION
This pull request introduces improvements to how pretrained model directories are resolved and managed across the `redeem-properties` and `redeem-properties-py` projects. The changes ensure consistent, cross-platform handling of model storage, update documentation to reflect the new search order, and add version detection to the Python package.

**Pretrained model directory resolution and storage improvements:**

* Introduced a new cross-platform function `default_pretrained_models_dir` in `redeem-properties/src/pretrained/mod.rs` to determine a stable user-local directory for pretrained models, prioritizing system-specific data directories and falling back to a local cache. All relevant code now uses this function for locating and caching models. [[1]](diffhunk://#diff-2578a90c411f39db70778683449b2b75fbed85b150ccd84041e8c34c81309347R51-R95) [[2]](diffhunk://#diff-2578a90c411f39db70778683449b2b75fbed85b150ccd84041e8c34c81309347L192-R243) [[3]](diffhunk://#diff-2578a90c411f39db70778683449b2b75fbed85b150ccd84041e8c34c81309347L266-R301) [[4]](diffhunk://#diff-2578a90c411f39db70778683449b2b75fbed85b150ccd84041e8c34c81309347L229-R271)
* Updated the pretrained model search order in documentation and code to prioritize the user-local directory, followed by development locations and working directory. Removed legacy paths and clarified error messages. [[1]](diffhunk://#diff-2578a90c411f39db70778683449b2b75fbed85b150ccd84041e8c34c81309347L173-R220) [[2]](diffhunk://#diff-2525707ea67f4533bfc4eae45a059395ecc87003f243d612284d117525dc262cL84-R85) [[3]](diffhunk://#diff-2525707ea67f4533bfc4eae45a059395ecc87003f243d612284d117525dc262cL175-R178) [[4]](diffhunk://#diff-2525707ea67f4533bfc4eae45a059395ecc87003f243d612284d117525dc262cL243-R245)
* Modified the download and extraction logic for pretrained models in `redeem-properties/src/utils/peptdeep_utils.rs` to use the new directory and correctly handle archive structure. Updated tests to verify the new location. [[1]](diffhunk://#diff-9a7c3989eb3cffaf9160437b306a440c943c752a9c031e112464191c740d5852L549-R552) [[2]](diffhunk://#diff-9a7c3989eb3cffaf9160437b306a440c943c752a9c031e112464191c740d5852L610-R632) [[3]](diffhunk://#diff-9a7c3989eb3cffaf9160437b306a440c943c752a9c031e112464191c740d5852L733-R748)

**Python package enhancements:**

* Added automatic package version detection to `redeem-properties-py/python/redeem_properties/__init__.py`, exporting `__version__` for improved introspection and compatibility. [[1]](diffhunk://#diff-0c0bdd2c7d6dcf470df01eadc1a3023ef8ba7dd5639ffe55af058d52ec54a278R36) [[2]](diffhunk://#diff-0c0bdd2c7d6dcf470df01eadc1a3023ef8ba7dd5639ffe55af058d52ec54a278R54) [[3]](diffhunk://#diff-0c0bdd2c7d6dcf470df01eadc1a3023ef8ba7dd5639ffe55af058d52ec54a278R69-R81)

**Version bump and cleanup:**

* Bumped package versions in `Cargo.toml` files for `redeem-classifiers`, `redeem-properties-py`, and `redeem-properties` to `0.1.1` to reflect these changes. [[1]](diffhunk://#diff-0b5f46a2edb2a09856acbdaa44ebe0b759b714fa5ac72d173f65cc496d6c3efbL3-R3) [[2]](diffhunk://#diff-6f025fd867acea2386dbb6134788397261ad4c10749b9198be6bac34ea0b1852L3-R3) [[3]](diffhunk://#diff-9c7da0e4787fd5a5a25627c70834cb41b4d5856719a369b38971452629fb53c1L3-R3)
* Removed unused constants and imports related to legacy model paths in `redeem-properties/src/utils/peptdeep_utils.rs`. [[1]](diffhunk://#diff-9a7c3989eb3cffaf9160437b306a440c943c752a9c031e112464191c740d5852L1-R1) [[2]](diffhunk://#diff-9a7c3989eb3cffaf9160437b306a440c943c752a9c031e112464191c740d5852L23-L24)

These updates make pretrained model handling more robust, portable, and user-friendly across both Rust and Python interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 0.1.1 across modules.

* **New Features**
  * Exposed runtime package __version__ for the Python package.

* **Improvements**
  * Unified and prioritized pretrained model discovery to use a cross-platform, user-local cache with clear fallback locations; updated extraction and caching to honor the configurable directory.
  * Tests updated to dynamically locate pretrained models instead of using hard-coded paths.

* **Documentation**
  * Updated registry and cache docs to reflect the new lookup and storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->